### PR TITLE
chore: add repo/bugs/homepage to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,14 @@
   "scripts": {
     "test": "estest test/test-*.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mikeal/ipjs.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mikeal/ipjs/issues"
+  },
+  "homepage": "https://github.com/mikeal/ipjs",
   "keywords": [],
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (https://www.mikealrogers.com/)",
   "license": "(Apache-2.0 AND MIT)",


### PR DESCRIPTION
Otherwise you can't find your way to the source code behind the module published at https://www.npmjs.com/package/ipjs