### PR TITLE
fix!: don't delete "main" in package.json

### DIFF
--- a/src/package/index.js
+++ b/src/package/index.js
@@ -53,8 +53,7 @@ class Package {
 
     const exports = {}
     if (!json.exports) {
-      if (!json.main) exports['.'] = { import: this.file(toURL('./index.js')) }
-      exports['.'] = { import: this.file(toURL(json.main)) }
+      exports['.'] = { import: this.file(toURL(json.main || './index.js')) }
     } else {
       for (const [key, value] of Object.entries(json.exports)) {
         if (typeof value === 'string') exports[key] = { import: this.file(toURL(value)) }
@@ -182,6 +181,7 @@ class Package {
     const json = copy(this.pkgjson)
 
     delete json.type
+    json.main = `./${join('./cjs', json.main || './index.js')}`
     json.browser = {}
     json.exports = {}
     const _join = (...args) => './' + join(...args)

--- a/src/package/index.js
+++ b/src/package/index.js
@@ -182,7 +182,6 @@ class Package {
     const json = copy(this.pkgjson)
 
     delete json.type
-    delete json.main
     json.browser = {}
     json.exports = {}
     const _join = (...args) => './' + join(...args)

--- a/test/fixtures/pkg-kitchensink/input/package.json
+++ b/test/fixtures/pkg-kitchensink/input/package.json
@@ -2,7 +2,7 @@
   "name": "pkg-kitchensink",
   "version": "0.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "src/index.js",
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/test/fixtures/pkg-kitchensink/output-notests/package.json
+++ b/test/fixtures/pkg-kitchensink/output-notests/package.json
@@ -2,6 +2,7 @@
   "name": "pkg-kitchensink",
   "version": "0.0.0",
   "description": "",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/fixtures/pkg-kitchensink/output-notests/package.json
+++ b/test/fixtures/pkg-kitchensink/output-notests/package.json
@@ -2,7 +2,7 @@
   "name": "pkg-kitchensink",
   "version": "0.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "./cjs/src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/fixtures/pkg-kitchensink/output-tests/package.json
+++ b/test/fixtures/pkg-kitchensink/output-tests/package.json
@@ -2,6 +2,7 @@
   "name": "pkg-kitchensink",
   "version": "0.0.0",
   "description": "",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/fixtures/pkg-kitchensink/output-tests/package.json
+++ b/test/fixtures/pkg-kitchensink/output-tests/package.json
@@ -2,7 +2,7 @@
   "name": "pkg-kitchensink",
   "version": "0.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "./cjs/src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
esbuild still doesn't support exports https://github.com/evanw/esbuild/issues/187
it's uncertain as yet what impact this might have on other bundlers and
loaders, hence this is a BREAKING CHANGE.