### PR TITLE
feat!: add optional --main for `build` to include "main"

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -25,6 +25,9 @@ const run = async opts => {
   pkg.dist = dist
   return pkg
 }
-run.schema = { tests: false }
+run.schema = {
+  tests: false,
+  main: false
+}
 
 export default run

--- a/src/package/index.js
+++ b/src/package/index.js
@@ -18,13 +18,14 @@ const { writeFile, mkdir, unlink, readdir, readFile, copyFile } = fs
 const plugins = [preserveShebangs.preserveShebangs()]
 
 class Package {
-  constructor ({ cwd, hooks, tests }) {
+  constructor ({ cwd, hooks, tests, main }) {
     this.cwd = cwd
     this.hooks = hooks || {}
     this.parsed = this.parse()
     this.files = new Map()
     this.testFiles = new Map()
     this.includeTests = tests
+    this.includeMain = main
   }
 
   file (url) {
@@ -181,7 +182,11 @@ class Package {
     const json = copy(this.pkgjson)
 
     delete json.type
-    json.main = `./${join('./cjs', json.main || './index.js')}`
+    if (this.includeMain) {
+      json.main = `./${join('./cjs', json.main || './index.js')}`
+    } else {
+      delete json.main
+    }
     json.browser = {}
     json.exports = {}
     const _join = (...args) => './' + join(...args)

--- a/test/fixtures/pkg-kitchensink/output-main/cjs/src/browser.js
+++ b/test/fixtures/pkg-kitchensink/output-main/cjs/src/browser.js
@@ -1,0 +1,11 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var sub = require('./sub.js');
+var browser = require('./sub/browser.js');
+
+
+
+exports.mod = sub;
+exports.sub = browser;

--- a/test/fixtures/pkg-kitchensink/output-main/cjs/src/deno.js
+++ b/test/fixtures/pkg-kitchensink/output-main/cjs/src/deno.js
@@ -1,0 +1,11 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var sub = require('./sub.js');
+var index = require('./sub/index.js');
+
+
+
+exports.mod = sub;
+exports.sub = index;

--- a/test/fixtures/pkg-kitchensink/output-main/cjs/src/index.js
+++ b/test/fixtures/pkg-kitchensink/output-main/cjs/src/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var sub = require('./sub.js');
+var index = require('./sub/index.js');
+
+
+
+exports.mod = sub;
+exports.sub = index;

--- a/test/fixtures/pkg-kitchensink/output-main/cjs/src/secondary.js
+++ b/test/fixtures/pkg-kitchensink/output-main/cjs/src/secondary.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var secondary = 'secondary';
+
+module.exports = secondary;

--- a/test/fixtures/pkg-kitchensink/output-main/cjs/src/sub.js
+++ b/test/fixtures/pkg-kitchensink/output-main/cjs/src/sub.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var sub = 'sub';
+
+module.exports = sub;

--- a/test/fixtures/pkg-kitchensink/output-main/cjs/src/sub/browser.js
+++ b/test/fixtures/pkg-kitchensink/output-main/cjs/src/sub/browser.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var browser = 'browser';
+
+module.exports = browser;

--- a/test/fixtures/pkg-kitchensink/output-main/cjs/src/sub/index.js
+++ b/test/fixtures/pkg-kitchensink/output-main/cjs/src/sub/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var index = 'import';
+
+module.exports = index;

--- a/test/fixtures/pkg-kitchensink/output-main/esm/package.json
+++ b/test/fixtures/pkg-kitchensink/output-main/esm/package.json
@@ -1,0 +1,1 @@
+{ "type" : "module" }

--- a/test/fixtures/pkg-kitchensink/output-main/esm/src/browser.js
+++ b/test/fixtures/pkg-kitchensink/output-main/esm/src/browser.js
@@ -1,0 +1,6 @@
+import mod from './sub.js';
+import sub from './sub/browser.js';
+export {
+  mod,
+  sub
+};

--- a/test/fixtures/pkg-kitchensink/output-main/esm/src/deno.js
+++ b/test/fixtures/pkg-kitchensink/output-main/esm/src/deno.js
@@ -1,0 +1,6 @@
+import mod from './sub.js';
+import sub from './sub/index.js';
+export {
+  mod,
+  sub
+};

--- a/test/fixtures/pkg-kitchensink/output-main/esm/src/index.js
+++ b/test/fixtures/pkg-kitchensink/output-main/esm/src/index.js
@@ -1,0 +1,6 @@
+import mod from './sub.js';
+import sub from './sub/index.js';
+export {
+  mod,
+  sub
+};

--- a/test/fixtures/pkg-kitchensink/output-main/esm/src/secondary.js
+++ b/test/fixtures/pkg-kitchensink/output-main/esm/src/secondary.js
@@ -1,0 +1,1 @@
+export default 'secondary';

--- a/test/fixtures/pkg-kitchensink/output-main/esm/src/sub.js
+++ b/test/fixtures/pkg-kitchensink/output-main/esm/src/sub.js
@@ -1,0 +1,1 @@
+export default 'sub';

--- a/test/fixtures/pkg-kitchensink/output-main/esm/src/sub/browser.js
+++ b/test/fixtures/pkg-kitchensink/output-main/esm/src/sub/browser.js
@@ -1,0 +1,1 @@
+export default 'browser';

--- a/test/fixtures/pkg-kitchensink/output-main/esm/src/sub/index.js
+++ b/test/fixtures/pkg-kitchensink/output-main/esm/src/sub/index.js
@@ -1,0 +1,1 @@
+export default 'import';

--- a/test/fixtures/pkg-kitchensink/output-main/package.json
+++ b/test/fixtures/pkg-kitchensink/output-main/package.json
@@ -2,6 +2,7 @@
   "name": "pkg-kitchensink",
   "version": "0.0.0",
   "description": "",
+  "main": "./cjs/src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/fixtures/pkg-kitchensink/output-tests/package.json
+++ b/test/fixtures/pkg-kitchensink/output-tests/package.json
@@ -2,7 +2,6 @@
   "name": "pkg-kitchensink",
   "version": "0.0.0",
   "description": "",
-  "main": "./cjs/src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -60,4 +60,13 @@ export default async test => {
     }
     */
   })
+
+  test('pkg-kitchensink w/ main', async test => {
+    const dist = pathToFileURL(await tempy.directory())
+    test.after(() => rmtree(fileURLToPath(dist)))
+    const opts = { cwd, dist, main: true }
+    await build(opts)
+    await verify(new URL('./output-main', url), dist)
+    await verify(dist, new URL('./output-main', url))
+  })
 }


### PR DESCRIPTION
Don't include "main" in package.json by default, but include it if --main is passed.

This winds back #7 to make inclusion of `"main"` an optional step if you provide a `--main` argument. esbuild has included `"exports"` support in 0.9.0, making this a little less critical I think since we now have very broad export map support. 🤞. Including a `"main"` broke TypeScript support in https://github.com/multiformats/js-multiformats - it's fixable, but it illustrates how fragile this all is so making it optional seems like a good idea.