### PR TITLE
fix: work with jest

### DIFF
--- a/test/fixtures/pkg-kitchensink/output-main/index.js
+++ b/test/fixtures/pkg-kitchensink/output-main/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./cjs/src/browser.js')

--- a/test/fixtures/pkg-kitchensink/output-main/secondary
+++ b/test/fixtures/pkg-kitchensink/output-main/secondary
@@ -1,0 +1,1 @@
+module.exports = require('./cjs/src/secondary.js')

--- a/test/fixtures/pkg-kitchensink/output-notests/index.js
+++ b/test/fixtures/pkg-kitchensink/output-notests/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./cjs/src/browser.js')

--- a/test/fixtures/pkg-kitchensink/output-notests/secondary
+++ b/test/fixtures/pkg-kitchensink/output-notests/secondary
@@ -1,0 +1,1 @@
+module.exports = require('./cjs/src/secondary.js')

--- a/test/fixtures/pkg-kitchensink/output-tests/index.js
+++ b/test/fixtures/pkg-kitchensink/output-tests/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./cjs/src/browser.js')

--- a/test/fixtures/pkg-kitchensink/output-tests/secondary
+++ b/test/fixtures/pkg-kitchensink/output-tests/secondary
@@ -1,0 +1,1 @@
+module.exports = require('./cjs/src/secondary.js')


### PR DESCRIPTION
Jest [doesn't support package exports](https://github.com/facebook/jest/issues/9771), nor does it support `browser` overrides out of the box (though it [can be configured](https://jestjs.io/docs/configuration#resolver-string)).

This means it parses the stubbed files introduced in #13 as javascript, so let's just require and export the file that the stub is stubbing.

This has the added bonus of also supporting old nodes that don't understand package exports.

Fixes achingbrain/uint8arrays#21