### PR TITLE
fix: windows build

### DIFF
--- a/src/package/index.js
+++ b/src/package/index.js
@@ -144,7 +144,7 @@ class Package {
         paths.push(...['./browser-', './node-'].map(n => n + rel.slice(2)))
       }
     }
-    const code = paths.map(p => `import("${p}")`).join('\n')
+    const code = paths.map(p => `import("${p.replace(/\\/g, '/')}")`).join('\n')
     const input = new URL(dist + '/esm/_ipjsInput.js')
     await writeFile(input, code)
     const onwarn = warning => {

--- a/src/path-to-url.js
+++ b/src/path-to-url.js
@@ -1,7 +1,6 @@
 // adapted from https://nodejs.org/api/path.html#path_path_resolve_paths
 const CHAR_FORWARD_SLASH = '/'
 const percentRegEx = /%/g
-const backslashRegEx = /\\/g
 const newlineRegEx = /\n/g
 const carriageReturnRegEx = /\r/g
 const tabRegEx = /\t/g
@@ -18,8 +17,6 @@ export default (filepath, cwd) => {
       resolved[resolved.length - 1] !== '/') { resolved += '/' }
   const outURL = new URL('file://')
   if (resolved.includes('%')) { resolved = resolved.replace(percentRegEx, '%25') }
-  // In posix, "/" is a valid character in paths
-  if (resolved.includes('\\')) { resolved = resolved.replace(backslashRegEx, '%5C') }
   if (resolved.includes('\n')) { resolved = resolved.replace(newlineRegEx, '%0A') }
   if (resolved.includes('\r')) { resolved = resolved.replace(carriageReturnRegEx, '%0D') }
   if (resolved.includes('\t')) { resolved = resolved.replace(tabRegEx, '%09') }


### PR DESCRIPTION
This PR fixes the ESM build in windows.

There were two issues with the specificities of paths in Windows that were not allowing windows builds:

- File URL path must not include encoded \ or / characters
- Cannot import ./indexjs from `/esm/_ipjsInput.js`

The first was basically because we were creating the following type of URL, which was problematic on its encodings.

```js
URL {
  href: 'file:///C:%5CUsers%5CRUNNER~1%5CAppData%5CLocal%5CTemp%5Cf0cb966061a76cc867b77cbb3dd07e18/package.json',
  origin: 'null',
  protocol: 'file:',
  username: '',
  password: '',
  host: '',
  hostname: '',
  port: '',
  pathname: '/C:%5CUsers%5CRUNNER~1%5CAppData%5CLocal%5CTemp%5Cf0cb966061a76cc867b77cbb3dd07e18/package.json',
  search: '',
  searchParams: URLSearchParams {},
  hash: ''
}
```

Error:

```
TypeError [ERR_INVALID_FILE_URL_PATH]: File URL path must not include encoded \ or / characters
```

The second error was due to the windows relative path obtained in windows came as `'./src\\index.js'`, meaning the generated code created was:

```js
import './indexjs' from `./esm/_ipjsInput.js`
```

Resolves #15 