### PR TITLE
feat: support single exports

### DIFF
--- a/src/package/index.js
+++ b/src/package/index.js
@@ -164,6 +164,10 @@ class Package {
   }
 
   async stubFiles (dist, overrides) {
+    if (typeof overrides === 'string') {
+      overrides = { '.': overrides }
+    }
+
     await Promise.all(
       Object.keys(overrides).map(async (file) => {
         const target = overrides[file]

--- a/src/package/index.js
+++ b/src/package/index.js
@@ -55,6 +55,8 @@ class Package {
     const exports = {}
     if (!json.exports) {
       exports['.'] = { import: this.file(toURL(json.main || './index.js')) }
+    } else if (typeof json.exports === 'string') {
+      exports['.'] = { import: this.file(toURL(json.exports)) }
     } else {
       for (const [key, value] of Object.entries(json.exports)) {
         if (typeof value === 'string') exports[key] = { import: this.file(toURL(value)) }

--- a/test/fixtures/pkg-single-export/input/index.js
+++ b/test/fixtures/pkg-single-export/input/index.js
@@ -1,0 +1,4 @@
+
+export default {
+  foo: 'bar'
+}

--- a/test/fixtures/pkg-single-export/input/package.json
+++ b/test/fixtures/pkg-single-export/input/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pkg-single-export",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (https://www.mikealrogers.com/)",
+  "license": "(Apache-2.0 AND MIT)",
+  "exports": {
+    "import": "./index.js"
+  }
+}

--- a/test/fixtures/pkg-single-export/input/test/index.js
+++ b/test/fixtures/pkg-single-export/input/test/index.js
@@ -1,0 +1,22 @@
+import * as mod from 'pkg-kitchensink'
+import secondary from 'pkg-kitchensink/secondary'
+import shared from './lib/shared.js'
+
+var window
+const type = window ? window.Deno ? 'deno' : 'browser' : 'import'
+
+const same = (x, y) => x === y
+
+export default test => {
+  test('sub import', () => {
+    same(mod.mod, 'sub')
+    same(mod.sub, type)
+  })
+  test('shared lib', () => {
+    same(shared.mod, 'sub')
+    same(shared.sub, type)
+  })
+  test('secondary', () => {
+    same(secondary, 'secondary')
+  })
+}

--- a/test/fixtures/pkg-single-export/output-main/cjs/index.js
+++ b/test/fixtures/pkg-single-export/output-main/cjs/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var index = { foo: 'bar' };
+
+module.exports = index;

--- a/test/fixtures/pkg-single-export/output-main/esm/index.js
+++ b/test/fixtures/pkg-single-export/output-main/esm/index.js
@@ -1,0 +1,1 @@
+export default { foo: 'bar' };

--- a/test/fixtures/pkg-single-export/output-main/esm/package.json
+++ b/test/fixtures/pkg-single-export/output-main/esm/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "browser": {}
+}

--- a/test/fixtures/pkg-single-export/output-main/index.js
+++ b/test/fixtures/pkg-single-export/output-main/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./cjs/index.js')

--- a/test/fixtures/pkg-single-export/output-main/package.json
+++ b/test/fixtures/pkg-single-export/output-main/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "pkg-single-export",
+  "version": "0.0.0",
+  "description": "",
+  "main": "./cjs/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (https://www.mikealrogers.com/)",
+  "license": "(Apache-2.0 AND MIT)",
+  "exports": {
+    "browser": "./esm/index.js",
+    "require": "./cjs/index.js",
+    "import": "./esm/index.js"
+  },
+  "browser": "./cjs/index.js"
+}

--- a/test/fixtures/pkg-string-export/input/index.js
+++ b/test/fixtures/pkg-string-export/input/index.js
@@ -1,0 +1,4 @@
+
+export default {
+  foo: 'bar'
+}

--- a/test/fixtures/pkg-string-export/input/package.json
+++ b/test/fixtures/pkg-string-export/input/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pkg-single-export",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (https://www.mikealrogers.com/)",
+  "license": "(Apache-2.0 AND MIT)",
+  "exports": "./index.js"
+}

--- a/test/fixtures/pkg-string-export/input/test/index.js
+++ b/test/fixtures/pkg-string-export/input/test/index.js
@@ -1,0 +1,22 @@
+import * as mod from 'pkg-kitchensink'
+import secondary from 'pkg-kitchensink/secondary'
+import shared from './lib/shared.js'
+
+var window
+const type = window ? window.Deno ? 'deno' : 'browser' : 'import'
+
+const same = (x, y) => x === y
+
+export default test => {
+  test('sub import', () => {
+    same(mod.mod, 'sub')
+    same(mod.sub, type)
+  })
+  test('shared lib', () => {
+    same(shared.mod, 'sub')
+    same(shared.sub, type)
+  })
+  test('secondary', () => {
+    same(secondary, 'secondary')
+  })
+}

--- a/test/fixtures/pkg-string-export/output-main/cjs/index.js
+++ b/test/fixtures/pkg-string-export/output-main/cjs/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var index = { foo: 'bar' };
+
+module.exports = index;

--- a/test/fixtures/pkg-string-export/output-main/esm/index.js
+++ b/test/fixtures/pkg-string-export/output-main/esm/index.js
@@ -1,0 +1,1 @@
+export default { foo: 'bar' };

--- a/test/fixtures/pkg-string-export/output-main/esm/package.json
+++ b/test/fixtures/pkg-string-export/output-main/esm/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "browser": {}
+}

--- a/test/fixtures/pkg-string-export/output-main/index.js
+++ b/test/fixtures/pkg-string-export/output-main/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./cjs/index.js')

--- a/test/fixtures/pkg-string-export/output-main/package.json
+++ b/test/fixtures/pkg-string-export/output-main/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "pkg-single-export",
+  "version": "0.0.0",
+  "description": "",
+  "main": "./cjs/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (https://www.mikealrogers.com/)",
+  "license": "(Apache-2.0 AND MIT)",
+  "exports": {
+    ".": {
+      "browser": "./esm/index.js",
+      "require": "./cjs/index.js",
+      "import": "./esm/index.js"
+    }
+  },
+  "browser": {
+    ".": "./cjs/index.js"
+  }
+}

--- a/test/fixtures/verify.js
+++ b/test/fixtures/verify.js
@@ -1,0 +1,29 @@
+import { promises as fs } from 'fs'
+import { deepStrictEqual as same } from 'assert'
+
+const eol = Buffer.from('\n')[0]
+
+const strip = buff => {
+  if (buff[buff.byteLength - 1] === eol) {
+    return buff.slice(0, buff.byteLength -2)
+  }
+  return buff
+}
+
+const verify = async (comp, input) => {
+  const files = await fs.readdir(comp)
+  for (const file of files) {
+    const url = new URL(comp + '/' + file)
+    const inputURL = new URL(input + '/' + file)
+    const stat = await fs.stat(url)
+    if (stat.isDirectory()) {
+      await verify(url, inputURL)
+    } else {
+      const valid = strip(await fs.readFile(url))
+      const data = strip(await fs.readFile(inputURL))
+      same(valid.toString(), data.toString())
+    }
+  }
+}
+
+export default verify

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -1,38 +1,12 @@
 import build from '../src/build.js'
 import tempy from 'tempy'
-import { promises as fs } from 'fs'
 import { fileURLToPath, pathToFileURL } from 'url'
 import rmtree from '@tgrajewski/rmtree'
-import { deepStrictEqual as same } from 'assert'
-
-const eol = Buffer.from('\n')[0]
-
-const strip = buff => {
-  if (buff[buff.byteLength - 1] === eol) {
-    return buff.slice(0, buff.byteLength -2)
-  }
-  return buff
-}
+import verify from './fixtures/verify.js'
 
 export default async test => {
   const url = new URL('fixtures/pkg-kitchensink/input', import.meta.url)
   const cwd = fileURLToPath(url)
-
-  const verify = async (comp, input) => {
-    const files = await fs.readdir(comp)
-    for (const file of files) {
-      const url = new URL(comp + '/' + file)
-      const inputURL = new URL(input + '/' + file)
-      const stat = await fs.stat(url)
-      if (stat.isDirectory()) {
-        await verify(url, inputURL)
-      } else {
-        const valid = strip(await fs.readFile(url))
-        const data = strip(await fs.readFile(inputURL))
-        same(valid.toString(), data.toString())
-      }
-    }
-  }
 
   test('pkg-kitchensink', async test => {
     const dist = pathToFileURL(await tempy.directory())

--- a/test/test-single-export.js
+++ b/test/test-single-export.js
@@ -1,0 +1,19 @@
+import build from '../src/build.js'
+import tempy from 'tempy'
+import { fileURLToPath, pathToFileURL } from 'url'
+import rmtree from '@tgrajewski/rmtree'
+import verify from './fixtures/verify.js'
+
+export default async test => {
+  const url = new URL('fixtures/pkg-single-export/input', import.meta.url)
+  const cwd = fileURLToPath(url)
+
+  test('pkg-single-export w/ main', async test => {
+    const dist = pathToFileURL(await tempy.directory())
+    test.after(() => rmtree(fileURLToPath(dist)))
+    const opts = { cwd, dist, main: true }
+    await build(opts)
+    await verify(new URL('./output-main', url), dist)
+    await verify(dist, new URL('./output-main', url))
+  })
+}

--- a/test/test-string-export.js
+++ b/test/test-string-export.js
@@ -1,0 +1,19 @@
+import build from '../src/build.js'
+import tempy from 'tempy'
+import { fileURLToPath, pathToFileURL } from 'url'
+import rmtree from '@tgrajewski/rmtree'
+import verify from './fixtures/verify.js'
+
+export default async test => {
+  const url = new URL('fixtures/pkg-string-export/input', import.meta.url)
+  const cwd = fileURLToPath(url)
+
+  test('pkg-string-export w/ main', async test => {
+    const dist = pathToFileURL(await tempy.directory())
+    test.after(() => rmtree(fileURLToPath(dist)))
+    const opts = { cwd, dist, main: true }
+    await build(opts)
+    await verify(new URL('./output-main', url), dist)
+    await verify(dist, new URL('./output-main', url))
+  })
+}


### PR DESCRIPTION
The following are all valid values for the `"exports"` map (https://nodejs.org/api/packages.html#packages_exports_sugar):

```
"exports": {
  ".": {
    "import": "./index.js"
  }
}
```

```
"exports": {
  "import": "./index.js"
}
```

```
"exports": "./index.js"
```

Currently ipjs only supports the first version, this PR adds support for the other two as well.