### PR TITLE
fix: require regular version in stubs

### DIFF
--- a/src/package/index.js
+++ b/src/package/index.js
@@ -183,10 +183,6 @@ class Package {
   }
 
   async stubFiles (dist, overrides) {
-    if (typeof overrides === 'string') {
-      overrides = { '.': overrides }
-    }
-
     await Promise.all(
       Object.keys(overrides).map(async (file) => {
         const target = overrides[file]
@@ -274,6 +270,7 @@ class Package {
       }
     }
     if (json.exports.import) {
+      // https://github.com/mikeal/ipjs/pull/18#issue-974673903
       json.exports = json.exports.import
       json.browser = json.browser.import
     }
@@ -285,6 +282,7 @@ class Package {
     pending.push(writeFile(new URL(dist + '/package.json'), JSON.stringify(json, null, 2)))
     const typeModule = {
       type: 'module',
+      // https://github.com/mikeal/ipjs/pull/12#issuecomment-879816902
       browser: esmBrowser
     }
     pending.push(writeFile(new URL(dist + '/esm/package.json'), JSON.stringify(typeModule, null, 2)))

--- a/test/fixtures/pkg-kitchensink/input/package.json
+++ b/test/fixtures/pkg-kitchensink/input/package.json
@@ -18,6 +18,10 @@
     },
     "./secondary": {
       "import": "./src/secondary.js"
+    },
+    "./tertiary": {
+      "browser": "./src/tertiary.browser.js",
+      "import": "./src/tertiary.js"
     }
   }
 }

--- a/test/fixtures/pkg-kitchensink/input/src/tertiary.browser.js
+++ b/test/fixtures/pkg-kitchensink/input/src/tertiary.browser.js
@@ -1,0 +1,1 @@
+export default 'tertiary.browser'

--- a/test/fixtures/pkg-kitchensink/input/src/tertiary.js
+++ b/test/fixtures/pkg-kitchensink/input/src/tertiary.js
@@ -1,0 +1,1 @@
+export default 'tertiary'

--- a/test/fixtures/pkg-kitchensink/output-main/cjs/src/tertiary.browser.js
+++ b/test/fixtures/pkg-kitchensink/output-main/cjs/src/tertiary.browser.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var tertiary_browser = 'tertiary.browser';
+
+module.exports = tertiary_browser;

--- a/test/fixtures/pkg-kitchensink/output-main/cjs/src/tertiary.js
+++ b/test/fixtures/pkg-kitchensink/output-main/cjs/src/tertiary.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var tertiary = 'tertiary';
+
+module.exports = tertiary;

--- a/test/fixtures/pkg-kitchensink/output-main/esm/package.json
+++ b/test/fixtures/pkg-kitchensink/output-main/esm/package.json
@@ -1,6 +1,7 @@
 {
   "type": "module",
   "browser": {
-    "./src/index.js": "./src/browser.js"
+    "./src/index.js": "./src/browser.js",
+    "./src/tertiary.js": "./src/tertiary.browser.js"
   }
 }

--- a/test/fixtures/pkg-kitchensink/output-main/esm/src/tertiary.browser.js
+++ b/test/fixtures/pkg-kitchensink/output-main/esm/src/tertiary.browser.js
@@ -1,0 +1,1 @@
+export default 'tertiary.browser';

--- a/test/fixtures/pkg-kitchensink/output-main/esm/src/tertiary.js
+++ b/test/fixtures/pkg-kitchensink/output-main/esm/src/tertiary.js
@@ -1,0 +1,1 @@
+export default 'tertiary';

--- a/test/fixtures/pkg-kitchensink/output-main/index.js
+++ b/test/fixtures/pkg-kitchensink/output-main/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./cjs/src/browser.js')
+module.exports = require('./cjs/src/index.js')

--- a/test/fixtures/pkg-kitchensink/output-main/package.json
+++ b/test/fixtures/pkg-kitchensink/output-main/package.json
@@ -19,12 +19,20 @@
       "browser": "./esm/src/secondary.js",
       "require": "./cjs/src/secondary.js",
       "import": "./esm/src/secondary.js"
+    },
+    "./tertiary": {
+      "browser": "./esm/src/tertiary.browser.js",
+      "require": "./cjs/src/tertiary.js",
+      "import": "./esm/src/tertiary.js"
     }
   },
   "browser": {
     ".": "./cjs/src/browser.js",
     "./esm/src/index.js": "./esm/src/browser.js",
     "./cjs/src/index.js": "./cjs/src/browser.js",
-    "./secondary": "./cjs/src/secondary.js"
+    "./secondary": "./cjs/src/secondary.js",
+    "./tertiary": "./cjs/src/tertiary.browser.js",
+    "./esm/src/tertiary.js": "./esm/src/tertiary.browser.js",
+    "./cjs/src/tertiary.js": "./cjs/src/tertiary.browser.js"
   }
 }

--- a/test/fixtures/pkg-kitchensink/output-main/tertiary
+++ b/test/fixtures/pkg-kitchensink/output-main/tertiary
@@ -1,0 +1,1 @@
+module.exports = require('./cjs/src/tertiary.js')

--- a/test/fixtures/pkg-kitchensink/output-notests/cjs/src/tertiary.browser.js
+++ b/test/fixtures/pkg-kitchensink/output-notests/cjs/src/tertiary.browser.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var tertiary_browser = 'tertiary.browser';
+
+module.exports = tertiary_browser;

--- a/test/fixtures/pkg-kitchensink/output-notests/cjs/src/tertiary.js
+++ b/test/fixtures/pkg-kitchensink/output-notests/cjs/src/tertiary.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var tertiary = 'tertiary';
+
+module.exports = tertiary;

--- a/test/fixtures/pkg-kitchensink/output-notests/esm/package.json
+++ b/test/fixtures/pkg-kitchensink/output-notests/esm/package.json
@@ -1,6 +1,7 @@
 {
   "type": "module",
   "browser": {
-    "./src/index.js": "./src/browser.js"
+    "./src/index.js": "./src/browser.js",
+    "./src/tertiary.js": "./src/tertiary.browser.js"
   }
 }

--- a/test/fixtures/pkg-kitchensink/output-notests/esm/src/tertiary.browser.js
+++ b/test/fixtures/pkg-kitchensink/output-notests/esm/src/tertiary.browser.js
@@ -1,0 +1,1 @@
+export default 'tertiary.browser';

--- a/test/fixtures/pkg-kitchensink/output-notests/esm/src/tertiary.js
+++ b/test/fixtures/pkg-kitchensink/output-notests/esm/src/tertiary.js
@@ -1,0 +1,1 @@
+export default 'tertiary';

--- a/test/fixtures/pkg-kitchensink/output-notests/index.js
+++ b/test/fixtures/pkg-kitchensink/output-notests/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./cjs/src/browser.js')
+module.exports = require('./cjs/src/index.js')

--- a/test/fixtures/pkg-kitchensink/output-notests/package.json
+++ b/test/fixtures/pkg-kitchensink/output-notests/package.json
@@ -18,12 +18,20 @@
       "browser": "./esm/src/secondary.js",
       "require": "./cjs/src/secondary.js",
       "import": "./esm/src/secondary.js"
+    },
+    "./tertiary": {
+      "browser": "./esm/src/tertiary.browser.js",
+      "require": "./cjs/src/tertiary.js",
+      "import": "./esm/src/tertiary.js"
     }
   },
   "browser": {
     ".": "./cjs/src/browser.js",
     "./esm/src/index.js": "./esm/src/browser.js",
     "./cjs/src/index.js": "./cjs/src/browser.js",
-    "./secondary": "./cjs/src/secondary.js"
+    "./secondary": "./cjs/src/secondary.js",
+    "./tertiary": "./cjs/src/tertiary.browser.js",
+    "./esm/src/tertiary.js": "./esm/src/tertiary.browser.js",
+    "./cjs/src/tertiary.js": "./cjs/src/tertiary.browser.js"
   }
 }

--- a/test/fixtures/pkg-kitchensink/output-notests/tertiary
+++ b/test/fixtures/pkg-kitchensink/output-notests/tertiary
@@ -1,0 +1,1 @@
+module.exports = require('./cjs/src/tertiary.js')

--- a/test/fixtures/pkg-kitchensink/output-tests/cjs/src/tertiary.browser.js
+++ b/test/fixtures/pkg-kitchensink/output-tests/cjs/src/tertiary.browser.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var tertiary_browser = 'tertiary.browser';
+
+module.exports = tertiary_browser;

--- a/test/fixtures/pkg-kitchensink/output-tests/cjs/src/tertiary.js
+++ b/test/fixtures/pkg-kitchensink/output-tests/cjs/src/tertiary.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var tertiary = 'tertiary';
+
+module.exports = tertiary;

--- a/test/fixtures/pkg-kitchensink/output-tests/esm/package.json
+++ b/test/fixtures/pkg-kitchensink/output-tests/esm/package.json
@@ -1,6 +1,7 @@
 {
   "type": "module",
   "browser": {
-    "./src/index.js": "./src/browser.js"
+    "./src/index.js": "./src/browser.js",
+    "./src/tertiary.js": "./src/tertiary.browser.js"
   }
 }

--- a/test/fixtures/pkg-kitchensink/output-tests/esm/src/tertiary.browser.js
+++ b/test/fixtures/pkg-kitchensink/output-tests/esm/src/tertiary.browser.js
@@ -1,0 +1,1 @@
+export default 'tertiary.browser';

--- a/test/fixtures/pkg-kitchensink/output-tests/esm/src/tertiary.js
+++ b/test/fixtures/pkg-kitchensink/output-tests/esm/src/tertiary.js
@@ -1,0 +1,1 @@
+export default 'tertiary';

--- a/test/fixtures/pkg-kitchensink/output-tests/index.js
+++ b/test/fixtures/pkg-kitchensink/output-tests/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./cjs/src/browser.js')
+module.exports = require('./cjs/src/index.js')

--- a/test/fixtures/pkg-kitchensink/output-tests/package.json
+++ b/test/fixtures/pkg-kitchensink/output-tests/package.json
@@ -18,12 +18,20 @@
       "browser": "./esm/src/secondary.js",
       "require": "./cjs/src/secondary.js",
       "import": "./esm/src/secondary.js"
+    },
+    "./tertiary": {
+      "browser": "./esm/src/tertiary.browser.js",
+      "require": "./cjs/src/tertiary.js",
+      "import": "./esm/src/tertiary.js"
     }
   },
   "browser": {
     ".": "./cjs/src/browser.js",
     "./esm/src/index.js": "./esm/src/browser.js",
     "./cjs/src/index.js": "./cjs/src/browser.js",
-    "./secondary": "./cjs/src/secondary.js"
+    "./secondary": "./cjs/src/secondary.js",
+    "./tertiary": "./cjs/src/tertiary.browser.js",
+    "./esm/src/tertiary.js": "./esm/src/tertiary.browser.js",
+    "./cjs/src/tertiary.js": "./cjs/src/tertiary.browser.js"
   }
 }

--- a/test/fixtures/pkg-kitchensink/output-tests/tertiary
+++ b/test/fixtures/pkg-kitchensink/output-tests/tertiary
@@ -1,0 +1,1 @@
+module.exports = require('./cjs/src/tertiary.js')


### PR DESCRIPTION
When we stub files for environments that do not handle export maps very well, we `require` a transpiled CJS implementation and re-export it in a stub file that should be immediately overriden by the `browser` or `exports` fields in `package.json`.

At the moment we use the value from the `browser` overrides to work out which file we should `require` the stub. The change here is to `require` the transpiled regular CJS version in the stub instead of the browser override.

Turns out when Jest has `testEnvironment: 'node'` set it resolves `require`s to the stubs, ignoring `exports` which loads browser-specific code into node with predictably incendiary results.