### PR TITLE
feat: windows support and drop 12.x + add 16.x in CI

### DIFF
--- a/.github/workflows/ipjs.yml
+++ b/.github/workflows/ipjs.yml
@@ -3,10 +3,12 @@ name: Build, Test and maybe Publish
 jobs:
   test:
     name: Build & Test
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
+        os: [macos-latest, ubuntu-latest] # pending estest support: windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -25,7 +27,9 @@ jobs:
     - name: Test
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: npm test
+      run: |
+        npm config set script-shell bash
+        npm test
   publish:
     name: Publish
     needs: test
@@ -47,7 +51,9 @@ jobs:
       if: steps.cache-modules.outputs.cache-hit != 'true'
       run: npm install
     - name: Test
-      run: npm test
+      run: |
+        npm config set script-shell bash
+        npm test
 
     - name: Publish
       uses: mikeal/merge-release@master

--- a/src/package/index.js
+++ b/src/package/index.js
@@ -11,6 +11,7 @@ import preserveShebangs from 'rollup-plugin-preserve-shebangs'
 const docFileRegex = /^(readme|license)/i
 
 const copy = o => JSON.parse(JSON.stringify(o))
+const cleanPath = (p) => p.replace(/\\/g, '/')
 const vals = Object.values
 
 const { writeFile, mkdir, unlink, readdir, readFile, copyFile } = fs
@@ -146,7 +147,7 @@ class Package {
         paths.push(...['./browser-', './node-'].map(n => n + rel.slice(2)))
       }
     }
-    const code = paths.map(p => `import("${p.replace(/\\/g, '/')}")`).join('\n')
+    const code = paths.map(p => `import("${cleanPath(p)}")`).join('\n')
     const input = new URL(dist + '/esm/_ipjsInput.js')
     await writeFile(input, code)
     const onwarn = warning => {
@@ -251,7 +252,7 @@ class Package {
     }
     json.browser = {}
     json.exports = {}
-    const _join = (...args) => './' + join(...args)
+    const _join = (...args) => `./${cleanPath(join(...args))}`
     const esmBrowser = {}
     for (const [key, ex] of Object.entries(this.exports)) {
       const _import = this.relative(await ex.import)
@@ -266,7 +267,7 @@ class Package {
         // https://github.com/mikeal/ipjs/pull/12#issue-943461643
         json.browser[_join('esm', _import)] = _join('esm', _browser)
         json.browser[_join('cjs', _import)] = _join('cjs', _browser)
-        esmBrowser[_import] = _browser
+        esmBrowser[cleanPath(_import)] = cleanPath(_browser)
       }
     }
     if (json.exports.import) {


### PR DESCRIPTION
I'm leaving out `windows-latest` from CI because estest uses a `#!/bin/sh` to get a strict unhandled rejections flag in; and I'm already 5 steps deep into this epic yak shave already and I have to stop somewhere! This works though, tested locally.

Currently the main dist exports map looks like this on Windows:

```json
  "exports": {
    ".": {
      "browser": "./esm\\src\\index.js",
      "require": "./cjs\\src\\index.js",
      "import": "./esm\\src\\index.js"
    },
    ...
```

And the esm/package.json looks like this:

```json
{
  "type": "module",
  "browser": {
    "./src\\hashes\\sha2.js": "./src\\hashes\\sha2-browser.js"
  }
}
```

So in the latter case it's both keys and values that are messed up. I've avoided using the `path.posix.*` route because it's really hard to get right for this kind of case and we know we're dealing with only local and (presumably) simply named paths so a basic replace should be good enough.